### PR TITLE
fix time zone format specification

### DIFF
--- a/chmed16a/README.md
+++ b/chmed16a/README.md
@@ -331,7 +331,7 @@ The *Med* object is the main one; it contains exactly one *Patient* object and a
   <td>R</td>
   <td>
 
-  Date of creation, Format: yyyy-mm-ddThh:mm:ss+02:00 ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) Combined date and time in UTC) (e.g. 2016-01-16T16:26:15+02:00)
+  Date of creation, Format: YYYY-MM-DDThh:mm:ss±hh:mm ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) Date and time with the offset) (e.g. 2016-06-16T16:26:15+02:00)
 
   </td>
 </tr>
@@ -365,7 +365,7 @@ The *Med* object is the main one; it contains exactly one *Patient* object and a
   <td>-</td>
   <td>
 
-  Validate date: Date of validation, Format: yyyy-mm-ddThh:mm:ss+02:00 ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) Combined date and time in UTC)
+  Validate date: Date of validation, Format: YYYY-MM-DDThh:mm:ss±hh:mm ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) Date and time with the offset)
 
   </td>
 </tr>
@@ -437,7 +437,7 @@ The *Med* object is the main one; it contains exactly one *Patient* object and a
   <td>R</td>
   <td>
 
-  Date of birth, Format: yyyy-mm-dd ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) Date)
+  Date of birth, Format: YYYY-MM-DD ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) Date)
 
   </td>
 </tr>
@@ -634,7 +634,7 @@ Applies only to MedicationPlan.
 
   Only required in case of _Risk Id_ 78 in _RiskCategory_ 3
 
-  First day of last menstruation, Format: yyyy-mm-dd ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) Date)
+  First day of last menstruation, Format: YYYY-MM-DD ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) Date)
 
   </td>
 </tr>
@@ -1107,7 +1107,7 @@ The possible risks are listed below. The allergies have not been listed here, yo
   <td>
 
   From date (start date of medication treatment),
-  Format: yyyy-mm-dd ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) Date)
+  Format: YYYY-MM-DD ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) Date)
   (e.g. 2016-01-16)
 
   </td>
@@ -1121,7 +1121,7 @@ The possible risks are listed below. The allergies have not been listed here, yo
   <td>
 
   To date (end date of medication treatment),
-  Format: yyyy-mm-dd ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) Date).
+  Format: YYYY-MM-DD ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) Date).
   The _DtTo_ must be considered as inclusive. For example DtTo: 2015-05-01, the patient must apply the medicament also on 2015-05-01.
 
   </td>

--- a/chmed16a/prescription.md
+++ b/chmed16a/prescription.md
@@ -305,7 +305,7 @@ The *Med* object is the main one; it contains exactly one *Patient* object and a
   <td>R</td>
   <td>
 
-  Date of creation, Format: yyyy-mm-ddThh:mm:ss+02:00 ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) Combined date and time in UTC) (e.g. 2016-01-16T16:26:15+02:00)
+  Date of creation, Format: YYYY-MM-DDThh:mm:ss±hh:mm ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) Date and time with the offset) (e.g. 2016-06-16T16:26:15+02:00)
 
   </td>
 </tr>
@@ -406,7 +406,7 @@ The *Med* object is the main one; it contains exactly one *Patient* object and a
   <td>R</td>
   <td>
 
-  Date of birth, Format: yyyy-mm-dd ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) Date)
+  Date of birth, Format: YYYY-MM-DD ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) Date)
 
   </td>
 </tr>
@@ -670,7 +670,7 @@ The *Med* object is the main one; it contains exactly one *Patient* object and a
   <td>
 
   To date (end date of medication treatment),
-  Format: yyyy-mm-dd ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) Date).
+  Format: YYYY-MM-DD ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) Date).
   The _DtTo_ must be considered as inclusive. For example DtTo: 2015-05-01, the patient must apply the medicament also on 2015-05-01.
 
   </td>

--- a/chmed23a/README.md
+++ b/chmed23a/README.md
@@ -369,8 +369,8 @@ The *Medication* object is the main object; it contains exactly one *Patient* an
 
   The date of creation
 
-  Format: yyyy-mm-ddThh:mm:ss+02:00
-  ([ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) Combined date and time in UTC)
+  Format: YYYY-MM-DDThh:mm:ss±hh:mm
+  ([ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) Date and time with the offset)
   (e.g. 2016-06-16T16:26:15+02:00)
  
   </td>
@@ -420,7 +420,7 @@ The *Patient* object contains the patient's personal and health data.
   <td>R</td>
   <td>
 
-  Date of birth, format: yyyy-mm-dd ([ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) Date)
+  Date of birth, format: YYYY-MM-DD ([ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) Date)
 
   </td>
 </tr>
@@ -639,7 +639,7 @@ The MedicalData object contains the patient's health data.
 
   Only required in case of <i>Risk Id</i> 78 in <i>RiskCategory</i> 3
 
-  First day of last menstruation, format: yyyy-mm-dd ([ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) Date)
+  First day of last menstruation, format: YYYY-MM-DD ([ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) Date)
 
   </td>
 </tr>
@@ -939,7 +939,7 @@ The table below describes the properties of a posology. Please refer to the [pos
 
   From date (start date of medication treatment),
 
-  format: YYYY-MM-DDThh:mm:ss+02:00 or YYYY-MM-DD
+  format: YYYY-MM-DDThh:mm:ss±hh:mm or YYYY-MM-DD
   ([ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) Combined date and time including time zone or date only)
   (e.g. 2016-06-16T16:26:15+02:00)
 
@@ -953,7 +953,7 @@ The table below describes the properties of a posology. Please refer to the [pos
   <td>
   To date (end date of medication treatment),
 
-  format: YYYY-MM-DDThh:mm:ss+02:00 or YYYY-MM-DD
+  format: YYYY-MM-DDThh:mm:ss±hh:mm or YYYY-MM-DD
   ([ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) Combined date and time including time zone or date only)
   (e.g. 2016-06-16T16:26:15+02:00)
 

--- a/chmed23a/posology.md
+++ b/chmed23a/posology.md
@@ -262,7 +262,7 @@ A posology CAN contain a start and an end date for the treatment and MUST specif
 
   From date (start date of medication treatment),
 
-  format: yyyy-mm-ddThh:mm:ss+02:00 ([ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) Combined date and time in UTC)
+  format: YYYY-MM-DDThh:mm:ss±hh:mm ([ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) Date and time with the offset)
   (e.g. 2016-06-16T16:26:15+02:00)
 
   </td>
@@ -276,7 +276,7 @@ A posology CAN contain a start and an end date for the treatment and MUST specif
 
   To date (end date of medication treatment),
 
-  format: yyyy-mm-ddThh:mm:ss+02:00 ([ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) Combined date and time in UTC)
+  format: YYYY-MM-DDThh:mm:ss±hh:mm ([ISO 8601](http://en.wikipedia.org/wiki/ISO_8601) Date and time with the offset)
   (e.g. 2016-06-16T16:26:15+02:00)
 
   The _DtTo_ must be considered as inclusive.


### PR DESCRIPTION
Use consistent datetime formatting instead of hardcoded '+02:00', which might be understood as the requirement to always deliver a fixed time zone.

Always use upper case date and lower case time like in the referred wikipedia article. The timezone specification is also according to the wikipedia article.
Additionally fix the example date `2016-01-16T16:26:15+02:00` to be in June because the time zone offset doesn't make sense for Switzerland in January.

Use the name from wikipedia (`Date and time with the offset`) for the format as well.